### PR TITLE
Use Require Once instead of Use for compatability

### DIFF
--- a/TLE/Parser.php
+++ b/TLE/Parser.php
@@ -7,9 +7,8 @@
  *
  * @link    https://github.com/ivanstan/tle Available on GitHub.
  */
-namespace TLE;
 
-use \TLE\Constant;
+require_once('Constant.php');
 
 /**
  * Class Parser.


### PR DESCRIPTION
Replace use \TLE\Constant with require_once('Constant.php') as I had difficulty utilizing spl_autoload_register() on Ubuntu 14.04 LTS.
